### PR TITLE
Add Cook-Torrance specular BRDF

### DIFF
--- a/Shaders/RayTrace.comp
+++ b/Shaders/RayTrace.comp
@@ -1,4 +1,4 @@
-﻿#version 450
+#version 450
 layout(local_size_x = 8, local_size_y = 8) in;
 
 layout(rgba32f, binding = 0) uniform image2D destImage;
@@ -65,6 +65,47 @@ vec3 sampleHemisphere(vec3 normal, inout uint seed) {
     vec3 bitangent = cross(normal, tangent);
 
     return normalize(x * tangent + y * bitangent + z * normal);
+}
+
+// -------------------- Cook-Torrance Specular BRDF --------------------
+vec3 fresnelSchlick(float cosTheta, vec3 F0)
+{
+    return F0 + (1.0 - F0) * pow(1.0 - cosTheta, 5.0);
+}
+
+float DistributionGGX(float NdotH, float roughness)
+{
+    float a  = roughness * roughness;
+    float a2 = a * a;
+    float denom = (NdotH * NdotH) * (a2 - 1.0) + 1.0;
+    return a2 / (PI * denom * denom);
+}
+
+float GeometrySchlickGGX(float NdotV, float roughness)
+{
+    float r = roughness + 1.0;
+    float k = (r * r) / 8.0;
+    return NdotV / (NdotV * (1.0 - k) + k);
+}
+
+float GeometrySmith(float NdotV, float NdotL, float roughness)
+{
+    return GeometrySchlickGGX(NdotV, roughness) * GeometrySchlickGGX(NdotL, roughness);
+}
+
+vec3 CookTorranceSpec(vec3 N, vec3 V, vec3 L, float roughness, vec3 F0)
+{
+    vec3 H = normalize(V + L);
+    float NdotL = max(dot(N, L), 0.0);
+    float NdotV = max(dot(N, V), 0.0);
+    float NdotH = max(dot(N, H), 0.0);
+    float VdotH = max(dot(V, H), 0.0);
+
+    float D = DistributionGGX(NdotH, roughness);
+    float G = GeometrySmith(NdotV, NdotL, roughness);
+    vec3 F = fresnelSchlick(VdotH, F0);
+
+    return (D * G * F) / max(4.0 * NdotV * NdotL, 0.001);
 }
 
 bool RaySphereIntersection(vec3 rayOrigin, vec3 rayDir, vec3 sphereCenter, float radius, out float t) {
@@ -171,9 +212,14 @@ vec3 TraceRay(vec3 camPos, vec3 camToPlaneDir, uint seed)
                 float lightDis = length(lightPos - hitPoint);
                 float lightAtten = lightStrength / (lightDis * lightDis);
 
-                finalColor += pathThroughput * sphereCol * lambert * lightAtten;
+                vec3 F0 = vec3(0.04);
+                vec3 spec = CookTorranceSpec(normal, normalize(-rayDir), lightDir, sphereRoughness, F0);
+
+                vec3 diffuse = sphereCol * lambert / PI;
+
+                finalColor += pathThroughput * (diffuse + spec) * lightAtten;
             }
-            pathThroughput *= sphereCol / PI; 
+            pathThroughput *= sphereCol / PI;
         }
         else
         {


### PR DESCRIPTION
## Summary
- implement Cook-Torrance specular BRDF helpers in compute shader
- use the specular BRDF when shading direct lighting
- remove UTF8 BOM to allow shader compilation

## Testing
- `apt-get update`
- `apt-get install -y glslang-tools`
- `glslangValidator -V Shaders/RayTrace.comp` *(fails: 'non-opaque uniforms outside a block')*

------
https://chatgpt.com/codex/tasks/task_e_6868111c1b0c83209b2d86b84570bc4d